### PR TITLE
Translation fix and add of power actions

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -64,6 +64,26 @@
       <label>Show icons next to menu items</label>
       <default>false</default>
     </entry>
+
+    <entry name="usePowerDialog" type="Bool">
+      <label>Use dialog box instead of lockscreen</label>
+      <default>false</default>
+    </entry>
+
+    <entry name="powerDialogCountdown" type="Int">
+      <label>Power dialog countdown in seconds</label>
+      <default>30</default>
+    </entry>
+
+    <entry name="quickAction" type="Bool">
+      <label>Skip confirmation when Action key is pressed</label>
+      <default>false</default>
+    </entry>
+
+    <entry name="quickActionModifier" type="String">
+      <label>Modifier key for quick action</label>
+      <default>Ctrl+Space</default>
+    </entry>
   </group>
 
   <group name="Custom">

--- a/package/contents/ui/MainMenuButton.qml
+++ b/package/contents/ui/MainMenuButton.qml
@@ -14,6 +14,8 @@ import org.kde.plasma.plasma5support as Plasma5Support
 AbstractButton {
     id: menuButton
 
+    focus: true
+
     readonly property string appStoreCommand: Plasmoid.configuration.appStoreCommand
         ?? Plasmoid.configuration.appStoreCommandDefault
     readonly property string aboutThisPCCommand: Plasmoid.configuration.aboutThisPCCommand
@@ -28,8 +30,14 @@ AbstractButton {
     readonly property bool showMenuItemIcons: Plasmoid.configuration.showMenuItemIcons ?? false
     readonly property bool showCustomCommandIcons: Plasmoid.configuration.showCustomCommandIcons ?? true
     readonly property string defaultCustomCommandIcon: Plasmoid.configuration.defaultCustomCommandIcon ?? "utilities-terminal"
+    readonly property bool usePowerDialog: Plasmoid.configuration.usePowerDialog ?? false
+    readonly property bool quickAction: Plasmoid.configuration.quickAction ?? false
+    readonly property string quickActionKeys: Plasmoid.configuration.quickActionModifier ?? "Ctrl+Space"
+    readonly property string ellipsis: "\u2026"
+    readonly property string ellipsisPlaceholder: "\u2007"
 
     property var customCommands: []
+    property bool actionKeyPressed : false
 
     function reloadCustomCommands() {
         const commands = []
@@ -61,6 +69,21 @@ AbstractButton {
             ? iconName
             : (defaultCustomCommandIcon?.length > 0 ? defaultCustomCommandIcon : "utilities-terminal")
     }
+
+    // QtLabs.MenuItem renders native menus outside the QML tree so once opened, ellipsis value doesn't bind and it's not longer evaluated again.
+    // So the Keys.onPressed approach works but has not visual feedback which leads to user confusion.
+    // The toggle solution using hidden QtLabs.MenuItem instead works because run as native menu.
+    //
+    //Keys.onPressed: function (event) {
+    //    if (!menuButton.quickAction || !menu.isOpened) return
+    //    if (event.key === Qt.Key_Space && (event.modifiers & Qt.ControlModifier)){
+    //        if (!event.isAutoRepeat){
+    //            menuButton.actionKeyPressed = !menuButton.actionKeyPressed
+    //            ellipsis = "\u2007"
+    //        }
+    //        event.accepted = true
+    //    }
+    //}
 
     RecentItems {
         id: recentItems
@@ -163,13 +186,22 @@ AbstractButton {
         readonly property int customCommandsEntryStartIndex: 4
 
         QtLabs.MenuItem {
+            visible: false
+            shortcut: quickActionKeys
+            enabled: menu.isOpened & menuButton.quickAction
+            onTriggered: {
+                menuButton.actionKeyPressed = !menuButton.actionKeyPressed
+            }
+        }
+
+        QtLabs.MenuItem {
             id: aboutThisPCMenuItem
             visible: Plasmoid.configuration.showAboutThisPCButton
-            text: i18n("About This PC")
+            text: i18n("About this PC")
             icon.name: menuButton.showMenuItemIcons ? "computer-laptop" : ""
             onTriggered: menuButton.aboutThisPCUseCommand
                 ? executable.exec(menuButton.aboutThisPCCommand)
-                : KCMLauncher.openInfoCenter("")
+                : executable.exec("kcmshell6 kcm_about-distro")
         }
 
         QtLabs.MenuSeparator {
@@ -275,7 +307,7 @@ AbstractButton {
 
         QtLabs.MenuItem {
             visible: Plasmoid.configuration.showForceQuitButton
-            text: i18n("Force Quit...")
+            text: i18n("Force Quit")
             icon.name: menuButton.showMenuItemIcons ? "process-stop-symbolic" : ""
             onTriggered: root.forceQuit.show()
             shortcut: Plasmoid.configuration.shortcutOpensPlasmoid ? null : plasmoid.globalShortcut
@@ -292,16 +324,46 @@ AbstractButton {
 
         QtLabs.MenuItem {
             visible: Plasmoid.configuration.showRestartButton
-            text: i18n("Restart...")
+            text: i18n("Restart") + (menuButton.actionKeyPressed ? menuButton.ellipsisPlaceholder : menuButton.ellipsis)
             icon.name: menuButton.showMenuItemIcons ? "system-reboot" : ""
-            onTriggered: sm.requestReboot()
+            onTriggered: {
+                if (menuButton.actionKeyPressed){
+                    sm.requestReboot(Sessions.SessionManagement.Skip)
+                }
+                else if (menuButton.usePowerDialog) {
+                    root.powerDialog.dialogTitle = i18n("Restart")
+                    root.powerDialog.dialogAction = i18n("the computer will restart")
+                    root.powerDialog.dialogIcon = "system-reboot"
+                    root.powerDialog.dialogMessage = i18n("Are you sure you want to restart you computer now?")
+                    root.powerDialog.confirmAction = function(){sm.requestReboot(Sessions.SessionManagement.Skip)}
+                    root.powerDialog.show()
+                }
+                else {
+                    sm.requestReboot()
+                }
+            }
         }
 
         QtLabs.MenuItem {
             visible: Plasmoid.configuration.showShutdownButton
-            text: i18n("Shut Down...")
+            text: i18n("Shut Down") + (menuButton.actionKeyPressed ? menuButton.ellipsisPlaceholder : menuButton.ellipsis)
             icon.name: menuButton.showMenuItemIcons ? "system-shutdown" : ""
-            onTriggered: sm.requestShutdown()
+            onTriggered: {
+                if (menuButton.actionKeyPressed){
+                    sm.requestShutdown(Sessions.SessionManagement.Skip)
+                }
+                else if (menuButton.usePowerDialog){
+                    root.powerDialog.dialogTitle = i18n("Shut Down")
+                    root.powerDialog.dialogAction = i18n("the computer will shut down")
+                    root.powerDialog.dialogIcon = "system-shutdown"
+                    root.powerDialog.dialogMessage = i18n("Are you sure you want to shut down you computer now?")
+                    root.powerDialog.confirmAction = function(){sm.requestShutdown(Sessions.SessionManagement.Skip)}
+                    root.powerDialog.show()
+                }
+                else {
+                    sm.requestShutdown()
+                }
+            }
         }
 
         QtLabs.MenuSeparator {}
@@ -316,15 +378,33 @@ AbstractButton {
 
         QtLabs.MenuItem {
             visible: Plasmoid.configuration.showLogOutButton
-            text: i18n("Log Out %1...", kUser.fullName)
+            text: i18n("Log Out %1", kUser.fullName) + (menuButton.actionKeyPressed ? menuButton.ellipsisPlaceholder : menuButton.ellipsis)
             icon.name: menuButton.showMenuItemIcons ? "system-log-out" : ""
             shortcut: "Ctrl+Alt+Delete"
-            onTriggered: sm.requestLogout()
+            onTriggered: {
+                if (menuButton.actionKeyPressed){
+                    sm.requestLogout(Sessions.SessionManagement.Skip)
+                }
+                else if (menuButton.usePowerDialog){
+                    root.powerDialog.dialogTitle = i18n("Log Out")
+                    root.powerDialog.dialogAction = i18n("you will be logged out")
+                    root.powerDialog.dialogIcon = "system-log-out"
+                    root.powerDialog.dialogMessage = i18n("Are you sure you want to quit all applications and log out now?")
+                    root.powerDialog.confirmAction = function(){sm.requestLogout(Sessions.SessionManagement.Skip)}
+                    root.powerDialog.show()
+                }
+                else {
+                    sm.requestLogout()
+                }
+            }
         }
 
-        onAboutToHide: menu.isOpened = false
+        onAboutToHide: {
+            menu.isOpened = false
+        }
         onAboutToShow: {
             menu.isOpened = true
+            menuButton.actionKeyPressed = false
             recentItems.loadRecentItems()
         }
     }
@@ -333,12 +413,25 @@ AbstractButton {
         id: executable
         engine: "executable"
         connectedSources: []
-        onNewData: function(source, data) {
-            disconnectSource(source)
+
+        property var pendingCallback: null
+
+        function exec(cmd, callback) {
+            pendingCallback = callback
+            connectSource(cmd)
         }
 
-        function exec(cmd) {
-            executable.connectSource(cmd)
+        onNewData: function(source, data) {
+            const exitCode = data["exit code"]
+
+            disconnectSource(source)
+
+            if (pendingCallback) {
+                const cb = pendingCallback
+                pendingCallback = null
+
+                cb(exitCode === 0)
+            }
         }
     }
 

--- a/package/contents/ui/config/configGeneral.qml
+++ b/package/contents/ui/config/configGeneral.qml
@@ -21,6 +21,10 @@ KCM.SimpleKCM {
     property string cfg_customButtonImage: Plasmoid.configuration.customButtonImage
     property bool cfg_resizeIconToRoot: resizeIconToRoot.checked
     property bool cfg_showMenuItemIcons: Plasmoid.configuration.showMenuItemIcons
+    property bool cfg_usePowerDialog: Plasmoid.configuration.usePowerDialog
+    property int cfg_powerDialogCountdown: Plasmoid.configuration.powerDialogCountdown
+    property bool cfg_quickAction: Plasmoid.configuration.quickAction
+    property string cgf_quickActionModifier: Plasmoid.configuration.quickActionModifier
 
     property bool cfg_shortcutOpensPlasmoid: Plasmoid.configuration.shortcutOpensPlasmoid
     property bool cfg_aboutThisPCUseCommand: Plasmoid.configuration.aboutThisPCUseCommand
@@ -44,8 +48,9 @@ KCM.SimpleKCM {
             id: useRectangleButtonShape
             currentIndex: configGeneral.cfg_useRectangleButtonShape ? 0 : 1
             Kirigami.FormData.label: i18n("Button shape")
-            model: [i18n("Rectangle"), i18n("Square")]
-
+            model: [i18n("Rectangle"),
+                    i18n("Square")]
+            //use separate lines so extract.rb be able to capture both
             onCurrentIndexChanged: {
                 configGeneral.cfg_useRectangleButtonShape = model[currentIndex] === i18n("Rectangle")
             }
@@ -71,6 +76,64 @@ KCM.SimpleKCM {
             text: i18n("Show icons next to menu items")
             checked: configGeneral.cfg_showMenuItemIcons
             onToggled: configGeneral.cfg_showMenuItemIcons = checked
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Power Actions")
+        }
+
+        CheckBox {
+            Kirigami.FormData.label: i18n("Power Dialog")
+            text: i18n("Use dialog box instead of lockscreen")
+            checked: configGeneral.cfg_usePowerDialog
+            onToggled: configGeneral.cfg_usePowerDialog = checked
+        }
+
+        SpinBox {
+            visible: configGeneral.cfg_usePowerDialog
+            Kirigami.FormData.label: i18n("Countdown Time")
+            from: 5
+            to: 60
+            value: configGeneral.cfg_powerDialogCountdown
+            onValueChanged: configGeneral.cfg_powerDialogCountdown = value
+        }
+
+        CheckBox {
+            Kirigami.FormData.label: i18n("Quick action")
+            text: i18n("Skip confirmation when Action key is pressed")
+            checked: configGeneral.cfg_quickAction
+            onToggled: configGeneral.cfg_quickAction = checked
+        }
+
+        Kirigami.ActionTextField {
+            id: quickActionModifier
+            visible: configGeneral.cfg_quickAction
+            Kirigami.FormData.label: i18n("Quick action shortcut")
+            text: Plasmoid.configuration.quickActionModifier ?? "Ctrl+Space"
+            placeholderText: "Ctrl+Space"
+            onTextEdited: {
+                configGeneral.cfg_quickActionModifier = quickActionModifier.text
+            }
+            rightActions: [
+                Action {
+                    icon.name: "edit-clear"
+                    enabled: quickActionModifier.text !== ""
+                    text: i18n("Clear field")
+                    onTriggered: {
+                        quickActionModifier.clear()
+                        configGeneral.cfg_quickActionModifier = ""
+                    }
+                },
+                Action {
+                    icon.name: "edit-reset"
+                    text: i18n("Reset default")
+                    onTriggered: {
+                        quickActionModifier.text = Plasmoid.configuration.quickActionModifierDefault
+                        configGeneral.cfg_quickActionModifier = Plasmoid.configuration.quickActionModifierDefault
+                    }
+                }
+            ]
         }
 
         Kirigami.Separator {

--- a/package/contents/ui/dialog/PowerDialog.qml
+++ b/package/contents/ui/dialog/PowerDialog.qml
@@ -1,0 +1,173 @@
+import QtQuick
+import QtQuick.Controls
+import org.kde.kirigami 2 as Kirigami
+import org.kde.plasma.plasmoid 2.0
+import org.kde.plasma.plasma5support as Plasma5Support
+
+Window {
+    id: "root"
+    title: dialogTitle
+    width: 480
+    height: 180
+
+    SystemPalette {
+        id: activePalette;
+        colorGroup: SystemPalette.Active
+    }
+    color: activePalette.window
+
+    visible: false
+    modality: Qt.ApplicationModal
+    flags: Qt.Dialog | Qt.WindowStaysOnTopHint
+    transientParent: null
+
+    property string dialogTitle: ""
+    property string dialogMessage: ""
+    property string dialogIcon: ""
+    property string dialogAction: ""
+    property bool autoConfirm: true
+    property var confirmAction
+
+    readonly property int countdownTime: Plasmoid.configuration.powerDialogCountdown ?? 30
+    property int countdown: countdownTime
+    property string defaultSaveSession: Plasmoid.configuration.defaultSaveSession
+
+    onVisibleChanged: {
+
+        if (visible) {
+            countdown = countdownTime
+            restoreSessionCheck.checked = (defaultSaveSession === "restoreLastSession")
+            if (autoConfirm) {
+                countdownTimer.start()
+            }
+        }
+        else {
+            countdownTimer.stop()
+            confirmAction = null
+        }
+    }
+
+    onActiveChanged: {
+        if (!active && countdownTimer.running) {
+            countdownTimer.stop()
+        }
+        else if (active && autoConfirm && countdown > 0){
+            countdownTimer.start()
+        }
+    }
+
+    Plasma5Support.DataSource {
+        id: sessionModeReader
+        engine: "executable"
+        connectedSources: ["kreadconfig6 --file ksmserverrc --group General --key loginMode --default restoreLastSession"]
+        onNewData: function(source, data) {
+            if (data["exit code"] === 0) {
+                console.log(data.stdout.trim())
+                root.defaultSaveSession = data.stdout.trim()
+            }
+        }
+    }
+
+    Plasma5Support.DataSource {
+        id: executable
+        engine: "executable"
+        connectedSources: []
+        onNewData: function(source, data) {
+            disconnectSource(source)
+        }
+    }
+
+    function executeAction(action) {
+        var desiredMode = restoreSessionCheck.checked ? "restoreLastSession" : "emptySession"
+        if (desiredMode !== defaultSaveSession) {
+            executable.connectSource("kwriteconfig6 --file ksmserverrc --group General --key loginMode " + desiredMode)
+        }
+        if (action){
+            action()
+        }
+    }
+
+    Timer {
+        id: countdownTimer
+
+        interval: 1000
+        repeat: true
+
+        onTriggered: {
+            countdown--
+            if (countdown <= 0) {
+                stop()
+                const action = confirmAction
+                root.hide()
+                if (action) {
+                    executeAction(action)
+                }
+            }
+        }
+    }
+
+    Column {
+        anchors.centerIn: parent
+        spacing: 16
+        width: root.width - 32
+
+        Row {
+            width: parent.width
+            spacing: 12
+
+            Kirigami.Icon {
+                source: dialogIcon
+                width: 64
+                height: 64
+            }
+
+            Column{
+                width: parent.width - 76
+                spacing: 12
+
+                Label {
+                    width: parent.width
+                    text: dialogMessage
+                    wrapMode: Text.WordWrap
+                }
+
+                Label {
+                    width: parent.width
+                    text: i18n("If you do nothing, %1 automatically in (%2) seconds.", dialogAction, countdown)
+                    wrapMode: Text.WordWrap
+                }
+
+                CheckBox {
+                    id: restoreSessionCheck
+                    text: i18n("Reopen windows when loggin back in")
+                }
+            }
+        }
+
+        Row {
+            anchors.right: parent.right
+            anchors.rightMargin: 12
+            spacing: 8
+
+            Button {
+                text: i18n("Cancel")
+                highlighted: true
+                onClicked: {
+                    root.hide()
+                }
+            }
+
+            Button {
+                text: dialogTitle
+                onClicked: {
+                    countdownTimer.stop()
+                    const action = confirmAction
+                    root.hide()
+                    if (action) {
+                        executeAction(action)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -12,6 +12,7 @@ PlasmoidItem  {
         : plasmoid.configuration.icon
 
     property Window forceQuit
+    property Window powerDialog
 
     preferredRepresentation: fullRepresentation
     compactRepresentation: null
@@ -32,6 +33,14 @@ PlasmoidItem  {
             return;
         }
         forceQuit = component.createObject(root)
+
+        const powerDialogComponent = Qt.createComponent("dialog/PowerDialog.qml")
+        if (powerDialogComponent.status !== Component.Ready) {
+             if (powerDialogComponent.status === Component.Error)
+                 console.debug("Error:" + powerDialogComponent.errorString());
+             return;
+        }
+        powerDialog = powerDialogComponent.createObject(root)
     }
 
     Plasmoid.icon: root.icon

--- a/package/translate/es.po
+++ b/package/translate/es.po
@@ -2,315 +2,389 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Darwin Menu\n"
 "Report-Msgid-Bugs-To: https://github.com/lasaczka\n"
-"POT-Creation-Date: 2026-05-25 03:12-0400\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"POT-Creation-Date: 2025-11-14 01:09+0300\n"
+"PO-Revision-Date: 2026-05-21 02:43+0000\n"
+"Last-Translator: Ignacio Gallardo <igna.gallardo.x@gmail.com>\n"
+"Language-Team: Spanish <es@li.org>\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+
 #: contents/config/config.qml:6
 msgid "General"
-msgstr ""
+msgstr "General"
+
 
 #: contents/config/config.qml:12
 msgid "Buttons"
-msgstr ""
+msgstr "Botones"
+
 
 #: contents/config/config.qml:18
 msgid "Custom commands"
-msgstr ""
+msgstr "Comandos Personalizados"
+
 
 #: contents/ui/ForceQuit/ConfirmationDialog.qml:81
 #. Preserve numbered parameters like %1, %2
 msgid "Do you want to force %1 to quit?"
-msgstr ""
+msgstr "Seguro que quires salid de %1"
+
 
 #: contents/ui/ForceQuit/ConfirmationDialog.qml:87
 msgid "You will lose any unsaved changes."
-msgstr ""
+msgstr "Se perderán los cambios no guardados."
+
 
 #: contents/ui/ForceQuit/ConfirmationDialog.qml:98
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
+
 
 #: contents/ui/ForceQuit/ConfirmationDialog.qml:105
 msgctxt "force quit action"
 msgid "Force Quit"
-msgstr ""
+msgstr "Forzar Salida"
+
 
 #: contents/ui/ForceQuit/ForceQuit.qml:45
 msgid "If an app doesn't respond for a while, select its name and click Force Quit."
-msgstr ""
+msgstr "Si una app no responde durante un tiempo, selecciónala y haz clic en Forzar Salida."
+
 
 #: contents/ui/ForceQuit/ForceQuit.qml:130
 msgid "Configure this window to open on global shortcut."
-msgstr ""
+msgstr "Configura esta ventana para abrirla con atajo global."
+
 
 #: contents/ui/ForceQuit/ForceQuit.qml:142
 #. Preserve numbered parameters like %1, %2
 msgid "You can open this window by pressing %1."
-msgstr ""
+msgstr "Puedes abrir esta ventana presionando %1"
+
 
 #: contents/ui/MainMenuButton.qml:185
 msgid "About this PC"
-msgstr ""
+msgstr "Acerca de este PC"
+
 
 #: contents/ui/MainMenuButton.qml:198
 msgid "Recent Items"
-msgstr ""
+msgstr "Elementos Recientes"
+
 
 #: contents/ui/MainMenuButton.qml:218
 msgid "Clear Menu"
-msgstr ""
+msgstr "Vaciar Menu"
+
 
 #: contents/ui/MainMenuButton.qml:225
 msgid "Refresh"
-msgstr ""
+msgstr "Actualizar"
+
 
 #: contents/ui/MainMenuButton.qml:241
 msgid "Commands"
-msgstr ""
+msgstr "Comandos"
+
 
 #: contents/ui/MainMenuButton.qml:278
 msgid "System Settings..."
-msgstr ""
+msgstr "Configuración del Sistema..."
+
 
 #: contents/ui/MainMenuButton.qml:286
 msgid "App Store..."
-msgstr ""
+msgstr "Tienda de Aplicaciones..."
+
 
 #: contents/ui/MainMenuButton.qml:305
 msgid "Sleep"
-msgstr ""
+msgstr "Reposo"
+
 
 #: contents/ui/MainMenuButton.qml:312
 msgid "Restart"
-msgstr ""
+msgstr "Reiniciar"
+
 
 #: contents/ui/MainMenuButton.qml:320
 msgid "the computer will restart"
-msgstr ""
+msgstr "la computadora se reiniciará"
+
 
 #: contents/ui/MainMenuButton.qml:322
 msgid "Are you sure you want to restart you computer now?"
-msgstr ""
+msgstr "¿Seguro que quieres reiniciar tu computadora ahora??"
+
 
 #: contents/ui/MainMenuButton.qml:334
 msgid "Shut Down"
-msgstr ""
+msgstr "Apagar equipo"
+
 
 #: contents/ui/MainMenuButton.qml:342
 msgid "the computer will shut down"
-msgstr ""
+msgstr "la computadora se apagará"
+
 
 #: contents/ui/MainMenuButton.qml:344
 msgid "Are you sure you want to shut down you computer now?"
-msgstr ""
+msgstr "¿Seguro que quieres apagar tu computadora ahora?"
+
 
 #: contents/ui/MainMenuButton.qml:358
 msgid "Lock Screen"
-msgstr ""
+msgstr "Bloquear pantalla"
+
 
 #: contents/ui/MainMenuButton.qml:366
 #. Preserve numbered parameters like %1, %2
 msgid "Log Out %1"
-msgstr ""
+msgstr "Cerrar Sesión de"
+
 
 #: contents/ui/MainMenuButton.qml:374
 msgid "Log Out"
-msgstr ""
+msgstr "Cerrar Sesión "
+
 
 #: contents/ui/MainMenuButton.qml:375
 msgid "you will be logged out"
-msgstr ""
+msgstr "se cerrará tu sesión"
+
 
 #: contents/ui/MainMenuButton.qml:377
 msgid "Are you sure you want to quit all applications and log out now?"
-msgstr ""
+msgstr "¿Seguro que quieres salir de todas las aplicaciones y cerrar la sesión ahora?"
+
 
 #: contents/ui/config/configButtons.qml:48
 msgid "About This PC"
-msgstr ""
+msgstr "Acerca de este sistema"
+
 
 #: contents/ui/config/configButtons.qml:49
 msgid "System Settings"
-msgstr ""
+msgstr "Configuración del Sistema"
+
 
 #: contents/ui/config/configButtons.qml:50
 msgid "App Store"
-msgstr ""
+msgstr "Tienda de Aplicaciones"
+
 
 #: contents/ui/config/configButtons.qml:54
 msgid "Shutdown"
-msgstr ""
+msgstr "Apagar equipo"
+
 
 #: contents/ui/config/configCustom.qml:41
 msgid "Show custom commands in separate menu"
-msgstr ""
+msgstr "Mostrar comandos personalizados en un menu aparte"
+
 
 #: contents/ui/config/configCustom.qml:48
 msgid "Custom commands menu title"
-msgstr ""
+msgstr "Título del menu de comandos personalizados"
+
 
 #: contents/ui/config/configCustom.qml:58
 msgid "Show icons for custom commands"
-msgstr ""
+msgstr "Mostrar iconos de comandos personalizados"
+
 
 #: contents/ui/config/configCustom.qml:65
 msgid "Default icon name"
-msgstr ""
+msgstr "Nombre de icono por defecto"
+
 
 #: contents/ui/config/configCustom.qml:81
 msgid "Add command"
-msgstr ""
+msgstr "Agregar comando"
+
 
 #: contents/ui/config/configCustom.qml:94
 msgid "Clear command list"
-msgstr ""
+msgstr "Limpiar lista de comandos"
+
 
 #: contents/ui/config/configCustom.qml:166
 msgid "Title"
-msgstr ""
+msgstr "Título"
+
 
 #: contents/ui/config/configCustom.qml:174
 msgid "Command"
-msgstr ""
+msgstr "Comando"
+
 
 #: contents/ui/config/configCustom.qml:182
 msgid "Icon"
-msgstr ""
+msgstr "Icono"
+
 
 #: contents/ui/config/configGeneral.qml:41
 msgid "Main"
-msgstr ""
+msgstr "Principal"
+
 
 #: contents/ui/config/configGeneral.qml:50
 msgid "Button shape"
-msgstr ""
+msgstr "Forma del botón"
+
 
 #: contents/ui/config/configGeneral.qml:51
 msgid "Rectangle"
-msgstr ""
+msgstr "Rectángulo"
+
 
 #: contents/ui/config/configGeneral.qml:52
 msgid "Square"
-msgstr ""
+msgstr "Cuadrado"
+
 
 #: contents/ui/config/configGeneral.qml:66
 msgid "Global shortcut opens:"
-msgstr ""
+msgstr "Atajo global abre:"
+
 
 #: contents/ui/config/configGeneral.qml:67
 msgid "Plasmoid"
-msgstr ""
+msgstr "Plasmoide"
+
 
 #: contents/ui/config/configGeneral.qml:75
 msgid "Menu items"
-msgstr ""
+msgstr "Elementos del menu"
+
 
 #: contents/ui/config/configGeneral.qml:76
 msgid "Show icons next to menu items"
-msgstr ""
+msgstr "Mostrar los iconos al lado del menu"
+
 
 #: contents/ui/config/configGeneral.qml:83
 msgid "Power Actions"
-msgstr ""
+msgstr "Acciones de Confirmación"
+
 
 #: contents/ui/config/configGeneral.qml:87
 msgid "Power Dialog"
-msgstr ""
+msgstr "Diálogo de confirmación"
+
 
 #: contents/ui/config/configGeneral.qml:88
 msgid "Use dialog box instead of lockscreen"
-msgstr ""
+msgstr "Usar diálogo en vez de pantalla de bloqueo"
+
 
 #: contents/ui/config/configGeneral.qml:95
 msgid "Countdown Time"
-msgstr ""
+msgstr "Cuenta Regresiva"
+
 
 #: contents/ui/config/configGeneral.qml:103
 msgid "Quick action"
-msgstr ""
+msgstr "Acción rápida"
+
 
 #: contents/ui/config/configGeneral.qml:104
 msgid "Skip confirmation when Action key is pressed"
-msgstr ""
+msgstr "Omitir confirmación cuando la tecla de accion este presionada"
+
 
 #: contents/ui/config/configGeneral.qml:112
 msgid "Quick action shortcut"
-msgstr ""
+msgstr "Atajo de Acción rápida"
+
 
 #: contents/ui/config/configGeneral.qml:122
 msgid "Clear field"
-msgstr ""
+msgstr "Limpiar campo"
+
 
 #: contents/ui/config/configGeneral.qml:130
 msgid "Reset default"
-msgstr ""
+msgstr "Resetar por defecto"
+
 
 #: contents/ui/config/configGeneral.qml:231
 msgctxt "@item:inmenu Open icon chooser dialog"
 msgid "Choose…"
-msgstr ""
+msgstr "Escoger..."
+
 
 #: contents/ui/config/configGeneral.qml:236
 msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
-msgstr ""
+msgstr "Limpiar icono"
+
 
 #: contents/ui/config/configGeneral.qml:253
 msgid "Icon size"
-msgstr ""
+msgstr "Tamaño del icono"
+
 
 #: contents/ui/config/configGeneral.qml:254
 msgid "Relative"
-msgstr ""
+msgstr "Relativo"
+
 
 #: contents/ui/config/configGeneral.qml:257
 msgid "Fixed"
-msgstr ""
+msgstr "Fijo"
+
 
 #: contents/ui/config/configGeneral.qml:323
 msgid "Preview icon size"
-msgstr ""
+msgstr "Vista previa"
+
 
 #: contents/ui/config/configGeneral.qml:338
 msgid "Fit to root element"
-msgstr ""
+msgstr "Fijar al objeto raiz"
+
 
 #: contents/ui/config/configGeneral.qml:371
 msgid "Override actions"
-msgstr ""
+msgstr "Sustituir Acciones"
+
 
 #: contents/ui/config/configGeneral.qml:381
 msgid "About This PC action"
-msgstr ""
+msgstr "Acerca de este sistema"
+
 
 #: contents/ui/config/configGeneral.qml:382
 msgid "System"
-msgstr ""
+msgstr "Sistema"
+
 
 #: contents/ui/config/configGeneral.qml:396
 msgid "About this PC command"
-msgstr ""
+msgstr "Acerca de este comando"
+
 
 #: contents/ui/config/configGeneral.qml:398
 msgid "Type here to override command"
-msgstr ""
+msgstr "Escribe aquí para reemplazar el comando"
+
 
 #: contents/ui/config/configGeneral.qml:429
 msgid "App Store command"
-msgstr ""
+msgstr "Comando de Tienda de Aplicaciones"
+
 
 #: contents/ui/dialog/PowerDialog.qml:102
 #. Preserve numbered parameters like %1, %2
 msgid "If you do nothing, %1 automatically in (%2) seconds."
-msgstr ""
+msgstr "Si no haces nada, %1 automáticamente en (%2) segundos."
+
 
 #: contents/ui/dialog/PowerDialog.qml:107
 msgid "Reopen windows when loggin back in"
-msgstr ""
+msgstr "Reabrir ventanas al iniciar sesión"
 

--- a/package/translate/pt_BR.po
+++ b/package/translate/pt_BR.po
@@ -18,250 +18,380 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+
 #: contents/config/config.qml:6
-msgctxt "i18n@config.qml:6"
 msgid "General"
 msgstr "Geral"
 
+
 #: contents/config/config.qml:12
-msgctxt "i18n@config.qml:12"
 msgid "Buttons"
 msgstr "Botões"
 
+
 #: contents/config/config.qml:18
-msgctxt "i18n@config.qml:18"
 msgid "Custom commands"
 msgstr "Comandos Personalisados"
 
+
+#: contents/ui/ForceQuit/ConfirmationDialog.qml:81
+#. Preserve numbered parameters like %1, %2
+msgid "Do you want to force %1 to quit?"
+msgstr "Deseja forçar o encerramento de %1"
+
+
 #: contents/ui/ForceQuit/ConfirmationDialog.qml:87
-msgctxt "i18n@ConfirmationDialog.qml:87"
 msgid "You will lose any unsaved changes."
 msgstr "Você irá perder alterações não salvas"
 
 
 #: contents/ui/ForceQuit/ConfirmationDialog.qml:98
-msgctxt "i18n@ConfirmationDialog.qml:98"
 msgid "Cancel"
 msgstr "Cancelar"
+
 
 #: contents/ui/ForceQuit/ConfirmationDialog.qml:105
 msgctxt "force quit action"
 msgid "Force Quit"
 msgstr "Forçar Encerramento"
 
+
 #: contents/ui/ForceQuit/ForceQuit.qml:45
-msgctxt "i18n@ForceQuit.qml:45"
 msgid "If an app doesn't respond for a while, select its name and click Force Quit."
 msgstr "Se algum app parar e responder por um tempo, selecione o nome e clique em Forçar Encerramento"
 
+
 #: contents/ui/ForceQuit/ForceQuit.qml:130
-msgctxt "i18n@ForceQuit.qml:130"
 msgid "Configure this window to open on global shortcut."
 msgstr "Configure esta janela para abrir em um atalho global."
 
-#: contents/ui/MainMenuButton.qml:136
-msgctxt "i18n@MainMenuButton.qml:136"
-msgid "About This PC"
+
+#: contents/ui/ForceQuit/ForceQuit.qml:142
+#. Preserve numbered parameters like %1, %2
+msgid "You can open this window by pressing %1."
+msgstr "Você pode abrir esta janela pressionando %1."
+
+
+#: contents/ui/MainMenuButton.qml:185
+msgid "About this PC"
 msgstr "Sobre este PC"
 
-#: contents/ui/MainMenuButton.qml:152
-msgctxt "i18n@MainMenuButton.qml:152"
+
+#: contents/ui/MainMenuButton.qml:198
+msgid "Recent Items"
+msgstr "Items Recentes"
+
+
+#: contents/ui/MainMenuButton.qml:218
+msgid "Clear Menu"
+msgstr "Limpar Menu"
+
+
+#: contents/ui/MainMenuButton.qml:225
+msgid "Refresh"
+msgstr "Atualizar"
+
+
+#: contents/ui/MainMenuButton.qml:241
 msgid "Commands"
 msgstr "Comandos"
 
-#: contents/ui/MainMenuButton.qml:189
-msgctxt "i18n@MainMenuButton.qml:189"
+
+#: contents/ui/MainMenuButton.qml:278
 msgid "System Settings..."
 msgstr "Configurações de Sistema..."
 
-#: contents/ui/MainMenuButton.qml:196
-msgctxt "i18n@MainMenuButton.qml:196"
+
+#: contents/ui/MainMenuButton.qml:286
 msgid "App Store..."
 msgstr "Loja de Aplicativos..."
 
-#: contents/ui/MainMenuButton.qml:204
-msgctxt "i18n@MainMenuButton.qml:204"
-msgid "Force Quit..."
-msgstr "Forçar Encerramento"
 
-#: contents/ui/MainMenuButton.qml:213
-msgctxt "i18n@MainMenuButton.qml:213"
+#: contents/ui/MainMenuButton.qml:305
 msgid "Sleep"
 msgstr "Hibernar"
 
-#: contents/ui/MainMenuButton.qml:219
-msgctxt "i18n@MainMenuButton.qml:219"
-msgid "Restart..."
-msgstr "Reiniciar..."
 
-#: contents/ui/MainMenuButton.qml:225
-msgctxt "i18n@MainMenuButton.qml:225"
-msgid "Shut Down..."
-msgstr "Desligar..."
-
-#: contents/ui/MainMenuButton.qml:233
-msgctxt "i18n@MainMenuButton.qml:233"
-msgid "Lock Screen"
-msgstr "Bloquear"
-
-#: contents/ui/config/configButtons.qml:49
-msgctxt "i18n@configButtons.qml:49"
-msgid "System Settings"
-msgstr "Configurações de Sistema"
-
-#: contents/ui/config/configButtons.qml:50
-msgctxt "i18n@configButtons.qml:50"
-msgid "App Store"
-msgstr "Loja de Aplicativos"
-
-#: contents/ui/config/configButtons.qml:53
-msgctxt "i18n@configButtons.qml:53"
+#: contents/ui/MainMenuButton.qml:312
 msgid "Restart"
 msgstr "Reiniciar"
 
 
+#: contents/ui/MainMenuButton.qml:320
+msgid "the computer will restart"
+msgstr "o computador será reiniciado"
+
+
+#: contents/ui/MainMenuButton.qml:322
+msgid "Are you sure you want to restart you computer now?"
+msgstr "Tem certeza que deseja reiniciar o computador agora?"
+
+
+#: contents/ui/MainMenuButton.qml:334
+msgid "Shut Down"
+msgstr "Desligar"
+
+
+#: contents/ui/MainMenuButton.qml:342
+msgid "the computer will shut down"
+msgstr "o computadora será desligado"
+
+
+#: contents/ui/MainMenuButton.qml:344
+msgid "Are you sure you want to shut down you computer now?"
+msgstr "Tem certeza que deseja desligar o computador agora?"
+
+
+#: contents/ui/MainMenuButton.qml:358
+msgid "Lock Screen"
+msgstr "Bloquear Tela"
+
+
+#: contents/ui/MainMenuButton.qml:366
+#. Preserve numbered parameters like %1, %2
+msgid "Log Out %1"
+msgstr "Encerrar sessão de %1"
+
+
+#: contents/ui/MainMenuButton.qml:374
+msgid "Log Out"
+msgstr "Encerrar sessão"
+
+
+#: contents/ui/MainMenuButton.qml:375
+msgid "you will be logged out"
+msgstr "sua sessão será encerrada"
+
+
+#: contents/ui/MainMenuButton.qml:377
+msgid "Are you sure you want to quit all applications and log out now?"
+msgstr "Tem certeza que deseja encerrar todos os aplicativos e sair agora?"
+
+
+#: contents/ui/config/configButtons.qml:48
+msgid "About This PC"
+msgstr "Sobre este PC"
+
+
+#: contents/ui/config/configButtons.qml:49
+msgid "System Settings"
+msgstr "Configurações de Sistema"
+
+
+#: contents/ui/config/configButtons.qml:50
+msgid "App Store"
+msgstr "Loja de Aplicativos"
+
+
 #: contents/ui/config/configButtons.qml:54
-msgctxt "i18n@configButtons.qml:54"
 msgid "Shutdown"
 msgstr "Desligar"
 
 
-#: contents/ui/config/configButtons.qml:56
-msgctxt "i18n@configButtons.qml:56"
-msgid "Log Out"
-msgstr "Encerrar sessão"
-
-#: contents/ui/config/configCustom.qml:20
-msgctxt "i18n@configCustom.qml:20"
+#: contents/ui/config/configCustom.qml:41
 msgid "Show custom commands in separate menu"
 msgstr "Mostrar comandos personalizados em menu separado"
 
-#: contents/ui/config/configCustom.qml:26
-msgctxt "i18n@configCustom.qml:26"
+
+#: contents/ui/config/configCustom.qml:48
 msgid "Custom commands menu title"
 msgstr "Título do menu de comandos personalizados"
 
-#: contents/ui/config/configCustom.qml:40
-msgctxt "i18n@configCustom.qml:40"
+
+#: contents/ui/config/configCustom.qml:58
+msgid "Show icons for custom commands"
+msgstr "Mostrar comandos personalizados em menu separado"
+
+
+#: contents/ui/config/configCustom.qml:65
+msgid "Default icon name"
+msgstr "Nome do ícone padrão"
+
+
+#: contents/ui/config/configCustom.qml:81
 msgid "Add command"
 msgstr "Adicionar comando"
 
-#: contents/ui/config/configCustom.qml:51
-msgctxt "i18n@configCustom.qml:51"
+
+#: contents/ui/config/configCustom.qml:94
 msgid "Clear command list"
 msgstr "Limpar lista de comandos"
 
-#: contents/ui/config/configCustom.qml:89
-msgctxt "i18n@configCustom.qml:89"
+
+#: contents/ui/config/configCustom.qml:166
 msgid "Title"
 msgstr "Titulo"
 
-#: contents/ui/config/configCustom.qml:99
-msgctxt "i18n@configCustom.qml:99"
+
+#: contents/ui/config/configCustom.qml:174
 msgid "Command"
 msgstr "Comando"
 
-#: contents/ui/config/configGeneral.qml:36
-msgctxt "i18n@configGeneral.qml:36"
-msgid "Main"
-msgstr "Principal"
 
-#: contents/ui/config/configGeneral.qml:45
-msgctxt "i18n@configGeneral.qml:45"
-msgid "Button shape"
-msgstr "Formato do Botão"
-
-#: contents/ui/config/configGeneral.qml:46
-msgctxt "i18n@configGeneral.qml:46"
-msgid "Rectangle"
-msgstr "Retangulo"
-
-#: contents/ui/config/configGeneral.qml:60
-msgctxt "i18n@configGeneral.qml:60"
-msgid "Global shortcut opens:"
-msgstr "Atalho global abre:"
-
-#: contents/ui/config/configGeneral.qml:61
-msgctxt "i18n@configGeneral.qml:61"
-msgid "Plasmoid"
-msgstr "Plasmoid"
-
-#: contents/ui/config/configGeneral.qml:70
-msgctxt "i18n@configGeneral.qml:70"
+#: contents/ui/config/configCustom.qml:182
 msgid "Icon"
 msgstr "Icone"
 
-#: contents/ui/config/configGeneral.qml:160
+
+#: contents/ui/config/configGeneral.qml:41
+msgid "Main"
+msgstr "Principal"
+
+
+#: contents/ui/config/configGeneral.qml:50
+msgid "Button shape"
+msgstr "Formato do Botão"
+
+
+#: contents/ui/config/configGeneral.qml:51
+msgid "Rectangle"
+msgstr "Retangulo"
+
+
+#: contents/ui/config/configGeneral.qml:52
+msgid "Square"
+msgstr "Quadrado"
+
+
+#: contents/ui/config/configGeneral.qml:66
+msgid "Global shortcut opens:"
+msgstr "Atalho global abre:"
+
+
+#: contents/ui/config/configGeneral.qml:67
+msgid "Plasmoid"
+msgstr "Plasmoid"
+
+
+#: contents/ui/config/configGeneral.qml:75
+msgid "Menu items"
+msgstr "Itens do Menu"
+
+
+#: contents/ui/config/configGeneral.qml:76
+msgid "Show icons next to menu items"
+msgstr "Mostrar ícones ao lado dos itens do menu"
+
+
+#: contents/ui/config/configGeneral.qml:83
+msgid "Power Actions"
+msgstr "Ações de Confirmação"
+
+
+#: contents/ui/config/configGeneral.qml:87
+msgid "Power Dialog"
+msgstr "Diálogo de Confirmação"
+
+
+#: contents/ui/config/configGeneral.qml:88
+msgid "Use dialog box instead of lockscreen"
+msgstr "Usar caixa de diálogo em vez da tela de bloequeio"
+
+
+#: contents/ui/config/configGeneral.qml:95
+msgid "Countdown Time"
+msgstr "Contagem Regressiva"
+
+
+#: contents/ui/config/configGeneral.qml:103
+msgid "Quick action"
+msgstr "Ação rápida"
+
+
+#: contents/ui/config/configGeneral.qml:104
+msgid "Skip confirmation when Action key is pressed"
+msgstr "Pular confirmação ao pressionar a tecla de ação"
+
+
+#: contents/ui/config/configGeneral.qml:112
+msgid "Quick action shortcut"
+msgstr "Atalho de Ação rápida"
+
+
+#: contents/ui/config/configGeneral.qml:122
+msgid "Clear field"
+msgstr "Limpar o campo"
+
+
+#: contents/ui/config/configGeneral.qml:130
+msgid "Reset default"
+msgstr "Redefinir padrão"
+
+
+#: contents/ui/config/configGeneral.qml:231
 msgctxt "@item:inmenu Open icon chooser dialog"
 msgid "Choose…"
 msgstr "Escolha..."
 
-#: contents/ui/config/configGeneral.qml:165
+
+#: contents/ui/config/configGeneral.qml:236
 msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Limpar icone"
 
-#: contents/ui/config/configGeneral.qml:182
-msgctxt "i18n@configGeneral.qml:182"
+
+#: contents/ui/config/configGeneral.qml:253
 msgid "Icon size"
 msgstr "Tamanho do icone"
 
-#: contents/ui/config/configGeneral.qml:183
-msgctxt "i18n@configGeneral.qml:183"
+
+#: contents/ui/config/configGeneral.qml:254
 msgid "Relative"
 msgstr "Relativo"
 
-#: contents/ui/config/configGeneral.qml:186
-msgctxt "i18n@configGeneral.qml:186"
+
+#: contents/ui/config/configGeneral.qml:257
 msgid "Fixed"
 msgstr "Fixo"
 
-#: contents/ui/config/configGeneral.qml:252
-msgctxt "i18n@configGeneral.qml:252"
+
+#: contents/ui/config/configGeneral.qml:323
 msgid "Preview icon size"
 msgstr "Visualizar tamanho do icone"
 
-#: contents/ui/config/configGeneral.qml:267
-msgctxt "i18n@configGeneral.qml:267"
+
+#: contents/ui/config/configGeneral.qml:338
 msgid "Fit to root element"
 msgstr "Ajustar ao elemento raiz"
 
-#: contents/ui/config/configGeneral.qml:300
-msgctxt "i18n@configGeneral.qml:300"
+
+#: contents/ui/config/configGeneral.qml:371
 msgid "Override actions"
 msgstr "Sobreescrever ações"
 
-#: contents/ui/config/configGeneral.qml:310
-msgctxt "i18n@configGeneral.qml:310"
+
+#: contents/ui/config/configGeneral.qml:381
 msgid "About This PC action"
 msgstr "Ação sobre este PC"
 
-#: contents/ui/config/configGeneral.qml:311
-msgctxt "i18n@configGeneral.qml:311"
+
+#: contents/ui/config/configGeneral.qml:382
 msgid "System"
 msgstr "Sistema"
 
-#: contents/ui/config/configGeneral.qml:325
-msgctxt "i18n@configGeneral.qml:325"
+
+#: contents/ui/config/configGeneral.qml:396
 msgid "About this PC command"
 msgstr "Comando Sobre este PC"
 
-#: contents/ui/config/configGeneral.qml:327
-msgctxt "i18n@configGeneral.qml:327"
+
+#: contents/ui/config/configGeneral.qml:398
 msgid "Type here to override command"
 msgstr "Digite pra sobreescrever o comando"
 
-#: contents/ui/config/configGeneral.qml:335
-msgctxt "i18n@configGeneral.qml:335"
-msgid "Clear field"
-msgstr "Limpar o campo"
 
-#: contents/ui/config/configGeneral.qml:343
-msgctxt "i18n@configGeneral.qml:343"
-msgid "Reset default"
-msgstr "Redefinir padrão"
-
-#: contents/ui/config/configGeneral.qml:358
-msgctxt "i18n@configGeneral.qml:358"
+#: contents/ui/config/configGeneral.qml:429
 msgid "App Store command"
 msgstr "Comando Loja de Aplicativos"
+
+
+#: contents/ui/dialog/PowerDialog.qml:102
+#. Preserve numbered parameters like %1, %2
+msgid "If you do nothing, %1 automatically in (%2) seconds."
+msgstr "Se você não fizer nada, %1 automaticamente em (%2) segundos."
+
+
+#: contents/ui/dialog/PowerDialog.qml:107
+msgid "Reopen windows when loggin back in"
+msgstr "Reabrir janelas ao iniciar sessão novamente"
+

--- a/package/translate/translation-lib/extract.rb
+++ b/package/translate/translation-lib/extract.rb
@@ -28,10 +28,11 @@ Find.find(SOURCE_DIR) do |path|
 
     File.readlines(path, chomp: true).each_with_index do |line, index|
         KEYWORDS.each do |kw, meta|
-            if line =~ /#{kw}\(\s*"((?:[^"\\]|\\.)*)"(?:\s*,\s*"((?:[^"\\]|\\.)*)")?\s*\)/
+            if line =~ /#{kw}\(\s*"((?:[^"\\]|\\.)*)"(?:\s*,\s*"((?:[^"\\]|\\.)*)")?[^)]*\)/
                     if meta[:args] == 1
-                msgid   = $1.encode('UTF-8')
-                context = "#{kw}@#{file_key}:#{index + 1}"
+                        msgid   = $1.encode('UTF-8')
+                        #context = "#{kw}@#{file_key}:#{index + 1}"
+                        context = nil
             elsif meta[:args] == 2
                 context = $1.encode('UTF-8')
                 msgid   = $2&.encode('UTF-8')
@@ -104,7 +105,7 @@ File.open(OUTPUT_FILE, 'w:utf-8') do |f|
     deduped.each_value do |entry|
         f.puts "#: #{entry[:file]}:#{entry[:line]}"
         f.puts "#. Preserve numbered parameters like %1, %2" if entry[:msgid] =~ /%[0-9]/
-                f.puts "msgctxt \"#{entry[:context].gsub(/["\\]/) { "\\#{_1}" }}\""
+        f.puts "msgctxt \"#{entry[:context].gsub(/["\\]/) { "\\#{_1}" }}\"" if entry[:context]
         f.puts "msgid \"#{entry[:msgid].gsub(/["\\]/) { "\\#{_1}" }}\""
         f.puts "msgstr \"\""
         f.puts

--- a/package/translate/translation-lib/merge.rb
+++ b/package/translate/translation-lib/merge.rb
@@ -26,6 +26,22 @@ def extract_id(entry)
     line.sub(/^msgid\s*/, '').strip
 end
 
+def extract_msgstr(entry)
+    line = entry.find { |l| l.start_with?('msgstr') }
+    return nil unless line
+    line.sub(/^msgstr\s*/, '').strip
+end
+
+def extract_msgctxt(entry)
+    line = entry.find { |l| l.start_with?('msgctxt') }
+    return nil unless line
+    line.sub(/^msgctxt\s*/, '').strip
+end
+
+def has_translation?(entry)
+    entry.any? { |l| l.start_with?('msgstr') && l !~ /^msgstr\s*""\s*$/ }
+end
+
 Color.echo "[merge] Updating .po files...", :cyan
 
 unless File.exist?(TEMPLATE)
@@ -35,66 +51,79 @@ end
 
 template_lines   = File.readlines(TEMPLATE)
 template_entries = parse_entries(template_lines)
-template_entries.reject! { |e| extract_id(e) == '""' }
+
+# Slipts .pot header (msgid "")
+pot_header  = template_entries.find  { |e| extract_id(e) == '""' }
+pot_entries = template_entries.reject { |e| extract_id(e) == '""' }
 
 Dir.glob("#{PO_DIR}/*.po").each do |po_path|
     Color.echo "[merge] Updating #{File.basename(po_path)}", :blue
 
-    po_lines = File.readlines(po_path)
+    po_lines   = File.readlines(po_path)
     po_entries = parse_entries(po_lines)
-    po_entries.reject! { |e| extract_id(e) == '""' }
 
-    seen = {}
-    deduped_po = []
+    # Keep .po header
+    po_header  = po_entries.find  { |e| extract_id(e) == '""' }
+    po_entries = po_entries.reject { |e| extract_id(e) == '""' }
+
+    # Build index of existing translations: msgid => entry. The key includes msgctxt to distinguish entries with context
+    po_index = {}
     po_entries.each do |entry|
-        id = extract_id(entry)
-        if seen[id]
-            Color.echo "  - Removed duplicate: #{id}", :dim
-            next
-        end
-        seen[id] = true
-        deduped_po << entry
+        id  = extract_id(entry)
+        ctx = extract_msgctxt(entry)
+        key = "#{ctx}|#{id}"
+        po_index[key] = entry
     end
 
-    po_ids  = deduped_po.map { |e| extract_id(e) }
-    pot_ids = template_entries.map { |e| extract_id(e) }
-    new_ids = pot_ids - po_ids
+    # Rebuild the .po file using the .pot file as a base. For each entry in the .pot file, search for an existing translation in the .po file
+    new_entries = pot_entries.map do |pot_entry|
+        id  = extract_id(pot_entry)
+        ctx = extract_msgctxt(pot_entry)
+        key = "#{ctx}|#{id}"
 
-    Color.echo "New entries to add: #{new_ids.size}", :cyan
+        existing = po_index[key] || po_index.values.find { |e| extract_id(e) == id }
+
+        if existing && has_translation?(existing)
+            msgstr = existing.find { |l| l.start_with?('msgstr') }
+            pot_entry.map { |l| l.start_with?('msgstr') ? msgstr : l }
+        else
+            pot_entry.map { |l| l.start_with?('msgstr') ? "msgstr \"\"\n" : l }
+        end
+    end
+
+    new_ids     = pot_entries.map { |e| extract_id(e) } -
+                  po_entries.map  { |e| extract_id(e) }
+    Color.echo "  New entries: #{new_ids.size}", :cyan
     new_ids.each { |id| Color.echo "    + #{id}", :yellow }
 
-    new_entries = template_entries.select { |e| new_ids.include?(extract_id(e)) }.map do |entry|
-        entry.map { |line| line.start_with?('msgstr') ? "msgstr \"\"\n" : line }
-    end
+    # If .po header doesn't exist, use .pot header instead
+    header = po_header || pot_header
 
-    merged = (deduped_po + new_entries).map { |e| e.join }.join("\n\n") + "\n"
+    parts  = []
+    parts << header.join if header
+    parts += new_entries.map { |e| e.join }
+    merged = parts.join("\n\n") + "\n"
+
     File.write(po_path, merged)
 end
 
 Color.echo "[merge] Done merging messages", :green
 Color.echo "[merge] Translation progress:", :cyan
 
-template_count = template_entries.count
-
+template_count = pot_entries.count
 rows = []
 rows << "| Locale   | Lines   | % Done |"
 rows << "|----------|---------|--------|"
 rows << "| Template | #{template_count.to_s.rjust(7)} |        |"
 
 Dir.glob("#{PO_DIR}/*.po").sort.each do |po_path|
-    locale = File.basename(po_path, '.po')
-    po_lines = File.readlines(po_path)
-    po_entries = parse_entries(po_lines)
-    po_entries.reject! { |e| extract_id(e) == '""' }
-
-    translated = po_entries.count do |entry|
-        entry.any? { |l| l.start_with?('msgstr') && l !~ /^msgstr\s*""\s*$/ }
-    end
-
-    percent      = ((translated.to_f / template_count) * 100).round
-    line_str     = "#{translated}/#{template_count}"
-    percent_str  = "#{percent}%".rjust(6)
-
+    locale      = File.basename(po_path, '.po')
+    po_lines    = File.readlines(po_path)
+    po_entries  = parse_entries(po_lines).reject { |e| extract_id(e) == '""' }
+    translated  = po_entries.count { |e| has_translation?(e) }
+    percent     = template_count > 0 ? ((translated.to_f / template_count) * 100).round : 0
+    line_str    = "#{translated}/#{template_count}"
+    percent_str = "#{percent}%".rjust(6)
     Color.echo "  #{locale.ljust(8)} #{line_str.ljust(10)} #{percent_str}", :blue
     rows << "| #{locale.ljust(8)} | #{line_str.rjust(7)} | #{percent_str} |"
 end


### PR DESCRIPTION
Fix extract and merge scripts:
- extract.rb no longer adds msgctxt to plain i18n() strings
- merge.rb preserves .po file headers and uses template.pot as base

Add power actions for Restart,. Shut Down and Log Out: 
- Quick action toggle to skip confirmation dialogs. 
- Alternative confirmation dialog with configurable countdown. 
- Session restore checkbox in confirmation dialog.

Add Spanish translation (es.po)
Complete Portuguese translation (pt_BR,po)